### PR TITLE
WIP Packaging for 8 -> 9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 __PKGNAME=$${_PKGNAME:-leapp-repository}
 VENVNAME ?= tut
+DIST_VERSION ?= 7
 PKGNAME=leapp-repository
-DEPS_PKGNAME=leapp-el7toel8-deps
+DEPS_PKGNAME=leapp-el8toel9-deps
 VERSION=`grep -m1 "^Version:" packaging/$(PKGNAME).spec | grep -om1 "[0-9].[0-9.]**"`
 DEPS_VERSION=`grep -m1 "^Version:" packaging/$(DEPS_PKGNAME).spec | grep -om1 "[0-9].[0-9.]**"`
 REPOS_PATH=repos
@@ -153,21 +154,21 @@ srpm: source
 	@rpmbuild -bs packaging/$(PKGNAME).spec \
 		--define "_sourcedir `pwd`/packaging/sources"  \
 		--define "_srcrpmdir `pwd`/packaging/SRPMS" \
-		--define "rhel 7" \
-		--define 'dist .el7' \
-		--define 'el7 1' || FAILED=1
+		--define "rhel $(DIST_VERSION)" \
+		--define 'dist .el$(DIST_VERSION)' \
+		--define 'el$(DIST_VERSION) 1' || FAILED=1
 	@mv packaging/$(PKGNAME).spec.bak packaging/$(PKGNAME).spec
 
 _srpm_subpkg:
 	@echo "--- Build RPM: $(DEPS_PKGNAME)-$(DEPS_VERSION)-$(RELEASE).. ---"
 	@cp packaging/$(DEPS_PKGNAME).spec packaging/$(DEPS_PKGNAME).spec.bak
 	@sed -i "s/1%{?dist}/$(RELEASE)%{?dist}/g" packaging/$(DEPS_PKGNAME).spec
-	@rpmbuild -bs packaging/$(DEPS_PKGNAME).spec \
+	rpmbuild -bs packaging/$(DEPS_PKGNAME).spec \
 		--define "_sourcedir `pwd`/packaging/sources"  \
 		--define "_srcrpmdir `pwd`/packaging/SRPMS" \
-		--define "rhel 8" \
-		--define 'dist .el8' \
-		--define 'el7 8' || FAILED=1
+		--define "rhel $$(($(DIST_VERSION) + 1))" \
+		--define "dist .el$$(($(DIST_VERSION) + 1))" \
+		--define "el$$(($(DIST_VERSION) + 1)) 1" || FAILED=1
 	@mv packaging/$(DEPS_PKGNAME).spec.bak packaging/$(DEPS_PKGNAME).spec
 
 _copr_build_deps_subpkg: _srpm_subpkg
@@ -179,7 +180,7 @@ _copr_build_deps_subpkg: _srpm_subpkg
 
 
 copr_build: srpm
-	@echo "--- Build RPM ${PKGNAME}-${VERSION}-${RELEASE}.el6.rpm in COPR ---"
+	@echo "--- Build RPM ${PKGNAME}-${VERSION}-${RELEASE}.el$(DIST_VERSION).rpm in COPR ---"
 	@echo copr --config $(_COPR_CONFIG) build $(_COPR_CHROOT) $(_COPR_REPO) \
 		packaging/SRPMS/${PKGNAME}-${VERSION}-${RELEASE}*.src.rpm
 	@copr --config $(_COPR_CONFIG) build $(_COPR_CHROOT) $(_COPR_REPO) \

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -3,6 +3,8 @@
 %global custom_repositorydir %{leapp_datadir}/custom-repositories
 # Defining py_byte_compile macro because it is not defined in old rpm (el7)
 # Only defined to python2 since python3 is not used in RHEL7
+# NOTE: this should not be problem as the macro should be defined on RHEL 8..
+# -- so it will be ignored..
 %{!?py_byte_compile: %global py_byte_compile py2_byte_compile() {\
     python_binary="%1"\
     bytecode_compilation_path="%2"\
@@ -22,7 +24,11 @@ URL:            https://oamg.github.io/leapp/
 Source0:        https://github.com/oamg/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1:        deps-pkgs.tar.gz
 BuildArch:      noarch
+%if 0%{?rhel} && 0%{?rhel} == 7
 BuildRequires:  python-devel
+%else
+BuildRequires:  python3-devel
+%endif
 
 # IMPORTANT: everytime the requirements are changed, increment number by one
 # - same for Provides in deps subpackage
@@ -31,16 +37,11 @@ Requires:       leapp-repository-dependencies = 5
 # IMPORTANT: this is capability provided by the leapp framework rpm.
 # Check that 'version' this instead of the real framework rpm version.
 Requires:       leapp-framework >= 1.3, leapp-framework < 2
+%if 0%{?rhel} && 0%{?rhel} == 7
 Requires:       python2-leapp
-
-# That's temporary to ensure the obsoleted subpackage is not installed
-# and will be removed when the current version of leapp-repository is installed
-Obsoletes:      leapp-repository-data <= 0.6.1
-Provides:       leapp-repository-data <= 0.6.1
-
-# Former leapp subpackage that was packacking a leapp sos plugin - the plugin
-# is part of the sos package since RHEL 7.8
-Obsoletes:      leapp-repository-sos-plugin <= 0.9.0
+%else
+Requires:       python3-leapp
+%endif
 
 %description
 Repositories for leapp
@@ -67,7 +68,10 @@ Requires:   python-pyudev
 # required by SELinux actors
 Requires:   policycoreutils-python
 %else ## RHEL 8 dependencies ##
-# Requires:   systemd-container
+Requires:   systemd-container
+Requires:   python3
+Requires:   python3-pyudev
+Requires:   policycoreutils-python-utils
 %endif
 ##################################################
 # end requirement
@@ -86,8 +90,11 @@ Requires:   policycoreutils-python
 %build
 # ??? what is supposed to be this? we do not have any build target in the makefile
 make build
+%if 0%{?rhel} && 0%{?rhel} == 7
 cp -a leapp*deps*rpm repos/system_upgrade/el7toel8/files/bundled-rpms/
-
+%else
+cp -a leapp*deps*rpm repos/system_upgrade/el8toel9/files/bundled-rpms/
+%endif
 
 %install
 install -m 0755 -d %{buildroot}%{custom_repositorydir}
@@ -101,6 +108,11 @@ install -m 0644 etc/leapp/transaction/* %{buildroot}%{_sysconfdir}/leapp/transac
 # Remove irrelevant repositories - We don't want to ship them
 rm -rf %{buildroot}%{repositorydir}/containerization
 rm -rf %{buildroot}%{repositorydir}/test
+%if 0%{?rhel} && 0%{?rhel} == 7
+rm -rf repos/system_upgrade/el8toel9/files/bundled-rpms/
+%else
+rm -rf repos/system_upgrade/el7toel8/files/bundled-rpms/
+%endif
 
 # remove component/unit tests, Makefiles, ... stuff that related to testing only
 rm -rf %{buildroot}%{repositorydir}/common/actors/testactor
@@ -119,7 +131,11 @@ done;
 # no choice as __python became error on F33+:
 #   https://fedoraproject.org/wiki/Changes/PythonMacroError
 # Maybe we will need to build SRPM over mock only on Fedora in future
+%if 0%{?rhel} && 0%{?rhel} == 7
 %py_byte_compile %{__python2} %{buildroot}%{repositorydir}/*
+%else
+%py_byte_compile %{__python3} %{buildroot}%{repositorydir}/*
+%endif
 
 
 %files


### PR DESCRIPTION
See FIXME and TODO comments. Also it needs leapp packages for Py3
(means another changes in leapp)

**Expected command for building now**
```
PR=6666 COPR_REPO=leapp9-poc DIST_VERSION=8 make copr_build
```

@mreznik: you can change default values in the Makefile to reduce it to typical  `make copr_build` if you want.

Leapp rpms are already built in the repo.